### PR TITLE
Remove opsmanagers email

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,7 @@ Make sure that your instructions for accessing or otherwise running your code ar
 
 Build your own public repo on github, and call it whatever you like. Build your solution in your
 repo, and include a README.md file that contains the detailed instructions for running your web app.
-Email the URL for your github repo to opsmanagers@britecore.com once you begin the project so we can review 
-your progress. Prior to submission, please bring up a live hosted example. AWS has a free tier if you 
-aren't certain where to host. Once your project is completed, please email opsmanagers@britecore.com.
+Once completed, please email the hiring manager or team that sent you the project request.
 
 One of the major goals in this project is to see how you fill in ambiguities in your own creative
 way. There is no such thing as a perfect project here, just interpretations of the instructions


### PR DESCRIPTION
Opsmanagers don't seem to be used widely for hiring anymore. Individual teams are sending projects out.